### PR TITLE
Generate abstract class, interface and trait stubs

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -220,8 +220,10 @@ abstract class Generator
             $class_info['class_keyword'] = 'trait';
         }
 
-        if ($reflection->isAbstract()) {
-            $class_info['abstract'] = $reflection->isAbstract();
+        
+        // Interfaces return true for isAbstract
+        if (!$reflection->isInterface() && $reflection->isAbstract()) {
+           $class_info['abstract'] = $reflection->isAbstract();
         }
 
         if ($reflection->isFinal()) {
@@ -312,6 +314,8 @@ abstract class Generator
         foreach ($methods as $method) {
             $method_info = array();
 
+            $method_info['interface'] = $class_info['class_keyword'] === 'interface';
+            $method_info['endWithSemicolon'] = $method_info['interface'];
             $method_info['name'] = $method->getName();
 
             $doccomment = $method->getDocComment();
@@ -337,6 +341,11 @@ abstract class Generator
             if ($method->isStatic()) {
                 $method_info['static'] = $method->isStatic();
                 $scope[] = 'static';
+            }
+
+            if (!$method_info['interface'] && $method->isAbstract()) {
+                $method_info['abstractMethod'] = $method->isAbstract();
+                $method_info['endWithSemicolon'] = $method->isAbstract();
             }
 
             $scope = implode(' ', $scope);

--- a/src/Strategy/OneFile.php
+++ b/src/Strategy/OneFile.php
@@ -88,8 +88,8 @@ class OneFile extends Generator
         // ---------------------------------------
 
         if (empty($template_variables['functions_by_namespace'])
-            || empty($template_variables['classes_by_namespace'])
-            || empty($template_variables['constants'])) {
+            && empty($template_variables['classes_by_namespace'])
+            && empty($template_variables['constants'])) {
             return;
         }
 

--- a/templates/onefile/onefile.mustache
+++ b/templates/onefile/onefile.mustache
@@ -33,7 +33,7 @@ namespace {{ name }}{
 {{# doccomment }}
 {{{ . | indent.tab_1 }}}
 {{/ doccomment }}
-	{{class_keyword}} {{short_name}}{{#extends}} extends {{.}}{{/extends}}{{#implements_string}} implements {{.}}{{/implements_string}}
+	{{#abstract}}abstract {{/abstract}}{{class_keyword}} {{short_name}}{{#extends}} extends {{.}}{{/extends}}{{#implements_string}} implements {{.}}{{/implements_string}}
 	{
 	{{# .constants }}
 	    const {{name}} = {{value}};
@@ -53,7 +53,7 @@ namespace {{ name }}{
 {{# doccomment }}
 {{{ . | indent.tab_2 }}}
 {{/ doccomment }}
-		function {{#returnsReference}}&{{/returnsReference}}{{ name }}({{# parameters}}{{#typeHint}}{{.}} {{/typeHint}}${{ name }}{{#defaultValue}} = {{.}}{{/defaultValue}}{{#comma}}, {{/comma}}{{/ parameters}}){}
+		{{#abstractMethod}}abstract {{/abstractMethod}}{{{ scope }}} function {{#returnsReference}}&{{/returnsReference}}{{ name }}({{# parameters}}{{#typeHint}}{{.}} {{/typeHint}}${{ name }}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{#comma}}, {{/comma}}{{/ parameters}}){{#endWithSemicolon}};{{/endWithSemicolon}}{{^endWithSemicolon}}{}{{/endWithSemicolon}}
 	{{/ methods }}
 
 	}


### PR DESCRIPTION
I have updated the Generator and the template for one file to display whether it is an abstract class and if the methods are abstract oder defined by an interface:

```PHP
// Before: the abstract class ends with brackets and displays error in the editor
abstract public function display_field($name, $value = '') {}

// New: Abstract methods end correctly with a semicolon:
abstract public function display_field($name, $value = '');
```
Kind regards,
Thomas

